### PR TITLE
updateGrant bug

### DIFF
--- a/access.go
+++ b/access.go
@@ -133,15 +133,14 @@ func IsOwner(req *http.Request, tokenStore reqHeaderOrHTTPCookie, key string) bo
 }
 
 func updateGrant(key, password string, cfg *Config) error {
-	var apiAccess *APIAccess
+	var apiAccess APIAccess
 	err := db.Store().View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(apiAccessStore))
 		if b == nil {
 			return fmt.Errorf("failed to get %s bucket to update grant", apiAccessStore)
 		}
-
 		j := b.Get([]byte(key))
-		return json.Unmarshal(j, apiAccess)
+		return json.Unmarshal(j, &apiAccess)
 	})
 	if err != nil {
 		return fmt.Errorf("failed to get access grant to update grant, %v", err)


### PR DESCRIPTION
Hey Steve,
While working with the ponzu access addon I always had problems updating the grant for a user.
I got the error message below in case you are interested.

With the changes I made everything is now working as expected. If I don't encounter any problems, than I will provide a usage example for the open issue of the access addon.

failed to update APIAccess grant for test.test@gmail.com, failed to get access grant to update grant, json: Unmarshal(nil *access.APIAccess)
2019/11/03 13:26:05 http: panic serving 127.0.0.1:43438: runtime error: invalid memory address or nil pointer dereference
goroutine 36 [running]:
net/http.(*conn).serve.func1(0xc000304dc0)
	/usr/local/go/src/net/http/server.go:1767 +0x139
panic(0xb65a80, 0x1282090)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/alpakaxaxa/skiday/cmd/ponzu/vendor/github.com/ponzu-cms/ponzu/content.login(0xd53cc0, 0xc00030c380, 0xc0001da000)
	/home/stephan/go/src/github.com/alpakaxaxa/skiday/cmd/ponzu/vendor/github.com/ponzu-cms/ponzu/content/user.go:313 +0x8b2
net/http.HandlerFunc.ServeHTTP(0xc75600, 0xd53cc0, 0xc00030c380, 0xc0001da000)
	/usr/local/go/src/net/http/server.go:2007 +0x44
net/http.(*ServeMux).ServeHTTP(0x1296940, 0xd53cc0, 0xc00030c380, 0xc0001da000)
	/usr/local/go/src/net/http/server.go:2387 +0x1bd
net/http.serverHandler.ServeHTTP(0xc001b747e0, 0xd53cc0, 0xc00030c380, 0xc0001da000)
	/usr/local/go/src/net/http/server.go:2802 +0xa4
net/http.(*conn).serve(0xc000304dc0, 0xd56040, 0xc0000a40c0)
	/usr/local/go/src/net/http/server.go:1890 +0x875
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:2927 +0x38e
